### PR TITLE
Moved lodash to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   "main": "./lib/src/CalendarHeatmap.js",
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.17.10",
     "prop-types": "^15.6.1"
   },
   "peerDependencies": {
+    "lodash": "^4.17.10",
     "react-native-svg": "^6.5.2"
   },
   "files": [


### PR DESCRIPTION
According to [Peer Dependencies in Readme.md](https://github.com/ayooby/react-native-calendar-heatmap#peer-dependencies) lodash should be a peer dependency.