### PR TITLE
Fix 7th day

### DIFF
--- a/lib/src/CalendarHeatmap.js
+++ b/lib/src/CalendarHeatmap.js
@@ -73,7 +73,7 @@ const CalendarHeatmap = props => {
   useEffect(() => {
     console.log("Value Cache: ", getValueCache(values));
     setValueCache(getValueCache(values));
-  }, []);
+  }, [values]);
 
   const [valueCache, setValueCache] = useState(getValueCache(values));
 

--- a/lib/src/utils/utils.js
+++ b/lib/src/utils/utils.js
@@ -130,7 +130,7 @@ function getSquareCoordinates(dayIndex, horizontal, gutterSize) {
 
 function getTransformForWeek(weekIndex, horizontal, gutterSize) {
   if (horizontal) {
-    return [weekIndex * getSquareSizeWithGutter(gutterSize), 50];
+    return [weekIndex * getSquareSizeWithGutter(gutterSize), 0];
   }
   return [10, weekIndex * getSquareSizeWithGutter(gutterSize)];
 }


### PR DESCRIPTION
Fixes https://github.com/ayooby/react-native-calendar-heatmap/issues/10, but breaks the month labels. Instead of 50 we should use height of the month labels. I don't use them, so it's fine for me.