### PR TITLE
Allow override month label and style

### DIFF
--- a/lib/src/CalendarHeatmap.js
+++ b/lib/src/CalendarHeatmap.js
@@ -47,7 +47,8 @@ const CalendarHeatmap = props => {
     monthLabelsColor,
     showMonthLabels,
     monthLabelsStyle,
-    colorArray
+    monthLabelForIndex,
+    colorArray,
   } = props;
 
   getValueCache = values => {
@@ -141,8 +142,16 @@ const CalendarHeatmap = props => {
         gutterSize,
       );
       return endOfWeek.getDate() >= 1 && endOfWeek.getDate() <= DAYS_IN_WEEK ? (
-        <Text {...monthLabelsStyle} key={weekIndex} x={x} y={y + 16} stroke={monthLabelsColor}>
-          {MONTH_LABELS[endOfWeek.getMonth()]}
+        <Text
+          {...monthLabelsStyle}
+          key={weekIndex}
+          x={x}
+          y={y + 16}
+          stroke={monthLabelsColor}
+        >
+          {monthLabelForIndex
+            ? monthLabelForIndex(endOfWeek.getMonth())
+            : MONTH_LABELS[endOfWeek.getMonth()]}
         </Text>
       ) : null;
     });

--- a/lib/src/CalendarHeatmap.js
+++ b/lib/src/CalendarHeatmap.js
@@ -73,7 +73,7 @@ const CalendarHeatmap = props => {
 
   useEffect(() => {
     setValueCache(getValueCache(values));
-  }, []);
+  }, [values]);
 
   const [valueCache, setValueCache] = useState(getValueCache(values));
 

--- a/lib/src/CalendarHeatmap.js
+++ b/lib/src/CalendarHeatmap.js
@@ -46,6 +46,7 @@ const CalendarHeatmap = props => {
     showOutOfRangeDays,
     monthLabelsColor,
     showMonthLabels,
+    monthLabelsStyle,
     colorArray
   } = props;
 
@@ -140,7 +141,7 @@ const CalendarHeatmap = props => {
         gutterSize,
       );
       return endOfWeek.getDate() >= 1 && endOfWeek.getDate() <= DAYS_IN_WEEK ? (
-        <Text key={weekIndex} x={x} y={y + 16} stroke={monthLabelsColor}>
+        <Text {...monthLabelsStyle} key={weekIndex} x={x} y={y + 16} stroke={monthLabelsColor}>
           {MONTH_LABELS[endOfWeek.getMonth()]}
         </Text>
       ) : null;


### PR DESCRIPTION
Thank you for creating this package. Migrating from react-native-chart-kit to this package, working great so far! 

I've forked a different fork that added `monthLabelsStyle` from @shingso, and also added `monthLabelForIndex` for localization. 