### PR TITLE
Arendedwinter patch 2

### DIFF
--- a/lib/src/CalendarHeatmap.js
+++ b/lib/src/CalendarHeatmap.js
@@ -49,6 +49,7 @@ const CalendarHeatmap = props => {
     monthLabelsStyle,
     monthLabelForIndex,
     colorArray,
+    dayNumberStyle, // New prop for day number styling
   } = props;
 
   getValueCache = values => {
@@ -85,28 +86,44 @@ const CalendarHeatmap = props => {
     }
   };
 
+  //  added dayNumber to the squares
   renderSquare = (dayIndex, index) => {
-    const indexOutOfRange =
-      index < getNumEmptyDaysAtStart(numDays, endDate) ||
-      index >= getNumEmptyDaysAtStart(numDays, endDate) + numDays;
-    if (indexOutOfRange && !showOutOfRangeDays) {
-      return null;
-    }
-    const [x, y] = getSquareCoordinates(dayIndex, horizontal, gutterSize);
-    const fillColor = getFillColor(index, valueCache, colorArray);
-    return (
-      <Rect
-        key={index}
-        width={SQUARE_SIZE}
-        height={SQUARE_SIZE}
-        x={x}
-        y={y}
-        title={getTitleForIndex(index, valueCache, titleForValue)}
-        onPress={() => handleClick(index)}
-        fill={fillColor}
-        {...getTooltipDataAttrsForIndex(index, valueCache, tooltipDataAttrs)}
-      />
-    );
+      const indexOutOfRange =
+          index < getNumEmptyDaysAtStart(numDays, endDate) ||
+          index >= getNumEmptyDaysAtStart(numDays, endDate) + numDays;
+      if (indexOutOfRange && !showOutOfRangeDays) {
+          return null;
+      }
+      const [x, y] = getSquareCoordinates(dayIndex, horizontal, gutterSize);
+      const fillColor = getFillColor(index, valueCache, colorArray);
+      const dayNumber = new Date(
+          shiftDate(getStartDateWithEmptyDays(numDays, endDate), index)
+      ).getDate();
+
+      return (
+          <G key={index}>
+              <Rect
+                  width={SQUARE_SIZE}
+                  height={SQUARE_SIZE}
+                  x={x}
+                  y={y}
+                  title={getTitleForIndex(index, valueCache, titleForValue)}
+                  onPress={() => handleClick(index)}
+                  fill={fillColor}
+                  {...getTooltipDataAttrsForIndex(index, valueCache, tooltipDataAttrs)}
+              />
+              <Text
+                  x={x + SQUARE_SIZE / 2}
+                  y={y + SQUARE_SIZE / 2}
+                  fontSize={dayNumberStyle?.fontSize || "10"}
+                  fill={dayNumberStyle?.color || "black"}
+                  textAnchor="middle"
+                  alignmentBaseline="central"
+              >
+                  {dayNumber}
+              </Text>
+          </G>
+      );
   };
 
   renderWeek = weekIndex => {
@@ -196,7 +213,11 @@ CalendarHeatmap.propTypes = {
   titleForValue: PropTypes.func, // function which returns title text for value
   classForValue: PropTypes.func, // function which returns html class for value
   onPress: PropTypes.func, // callback function when a square is clicked
-  colorArray: PropTypes.array
+  colorArray: PropTypes.array,
+  dayNumberStyle: PropTypes.shape({
+        fontSize: PropTypes.string,
+        color: PropTypes.string
+    }) // New prop for day number styling
 };
 
 CalendarHeatmap.defaultProps = {
@@ -209,7 +230,11 @@ CalendarHeatmap.defaultProps = {
   showOutOfRangeDays: false,
   colorArray: rectColor,
   classForValue: value => (value ? "black" : "#8cc665"),
-  onPress: () => console.log("change onPress prop")
+  onPress: () => console.log("change onPress prop"),
+  dayNumberStyle: {
+        fontSize: "10",
+        color: "black"
+    } // Default styling
 };
 
 export default CalendarHeatmap;

--- a/lib/src/CalendarHeatmap.js
+++ b/lib/src/CalendarHeatmap.js
@@ -50,6 +50,7 @@ const CalendarHeatmap = props => {
     monthLabelForIndex,
     colorArray,
     dayNumberStyle, // New prop for day number styling
+    showDayNumbersForEntriesOnly, // New prop for conditional day number display
   } = props;
 
   getValueCache = values => {
@@ -100,6 +101,9 @@ const CalendarHeatmap = props => {
           shiftDate(getStartDateWithEmptyDays(numDays, endDate), index)
       ).getDate();
 
+      // Only show day number if there is an entry or if showDayNumbersForEntriesOnly is false
+      const shouldShowDayNumber = !showDayNumbersForEntriesOnly || valueCache[index];
+    
       return (
           <G key={index}>
               <Rect
@@ -112,16 +116,18 @@ const CalendarHeatmap = props => {
                   fill={fillColor}
                   {...getTooltipDataAttrsForIndex(index, valueCache, tooltipDataAttrs)}
               />
-              <Text
-                  x={x + SQUARE_SIZE / 2}
-                  y={y + SQUARE_SIZE / 2}
-                  fontSize={dayNumberStyle?.fontSize || "10"}
-                  fill={dayNumberStyle?.color || "black"}
-                  textAnchor="middle"
-                  alignmentBaseline="central"
-              >
-                  {dayNumber}
-              </Text>
+              {shouldShowDayNumber && (
+                  <Text
+                      x={x + SQUARE_SIZE / 2}
+                      y={y + SQUARE_SIZE / 2}
+                      fontSize={dayNumberStyle?.fontSize || "10"}
+                      fill={dayNumberStyle?.color || "black"}
+                      textAnchor="middle"
+                      alignmentBaseline="central"
+                  >
+                      {dayNumber}
+                  </Text>
+              )}
           </G>
       );
   };
@@ -217,7 +223,8 @@ CalendarHeatmap.propTypes = {
   dayNumberStyle: PropTypes.shape({
         fontSize: PropTypes.string,
         color: PropTypes.string
-    }) // New prop for day number styling
+    }), // New prop for day number styling
+  showDayNumbersForEntriesOnly: PropTypes.bool, // New prop for conditional day number display
 };
 
 CalendarHeatmap.defaultProps = {
@@ -234,7 +241,8 @@ CalendarHeatmap.defaultProps = {
   dayNumberStyle: {
         fontSize: "10",
         color: "black"
-    } // Default styling
+    }, // Default styling
+  showDayNumbersForEntriesOnly: false, // Default to showing day numbers for all days
 };
 
 export default CalendarHeatmap;


### PR DESCRIPTION
Update to the CalendarHeatmap.js to add Day numubers to the squares.   New prop introduced usage as below;

```
dayNumberStyle={{
    fontSize: "8", // Customize font size
    color: "#333",  // Customize text color
}}
```
		  
In addition to the above, another prop was added to control when the day numbers would be shown.  If true, they will only show when there is a date in the value array.
  
`showDayNumbersForEntriesOnly={true} // Set to true to only show day numbers where there is an entry`